### PR TITLE
S3Client config: make request checksum calculation optional

### DIFF
--- a/file/file.go
+++ b/file/file.go
@@ -44,6 +44,7 @@ func UploadToS3(filename string) error {
 					}, nil
 				},
 			)),
+			config.WithRequestChecksumCalculation(aws.RequestChecksumCalculationWhenRequired),
 		)
 	} else {
 		cfg, err = config.LoadDefaultConfig(context.TODO(),

--- a/main.go
+++ b/main.go
@@ -76,6 +76,7 @@ func init() {
 						}, nil
 					},
 				)),
+				config.WithRequestChecksumCalculation(aws.RequestChecksumCalculationWhenRequired),
 			)
 		} else {
 			cfg, err = config.LoadDefaultConfig(context.Background(),


### PR DESCRIPTION
Only calculate checksums when required by S3 backend, new default since aws-sdk-go-v2 v1.73.0 is always.

cf.
- announcement: https://github.com/aws/aws-sdk-go-v2/discussions/2960
- issue: https://github.com/aws/aws-sdk-go-v2/issues/3003

Closes #31 